### PR TITLE
Fixed complaint about pointer being *const

### DIFF
--- a/src/kv_cursor.rs
+++ b/src/kv_cursor.rs
@@ -332,7 +332,7 @@ impl RawCursor {
         *self.cursor
     }
     unsafe fn engine(&self) -> *mut unqlite {
-        *self.engine
+        *self.engine as *mut ::ffi::unqlite
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,7 +258,7 @@ impl UnQLite {
     }
 
     unsafe fn as_raw_mut_ptr(&self) -> *mut ::ffi::unqlite {
-        *self.engine
+        *self.engine as *mut ::ffi::unqlite
     }
 }
 


### PR DESCRIPTION
Latest nightly complained about the return type being *const rather than *mut, the added coercion fixes the compiler error