### PR TITLE
Implement Send for Error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -16,6 +16,8 @@ pub enum Error {
     Other(Box<error::Error>),
 }
 
+unsafe impl Send for Error {}
+
 impl From<Custom> for Error {
     fn from(err: Custom) -> Error {
         Error::Custom(err)


### PR DESCRIPTION
Implement Send for Error so that it could be used in structs and traits requiring any error E to be E: Error + Send + 'static (e.g.: generally Result).