### PR TITLE
Derive clone for UnQLiteVm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 Cargo.lock
 *.bk
 src/ffi.rs
+rls

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unqlite"
-version = "1.4.0"
+version = "1.4.1"
 authors = ["Huo Linhe <huolinhe@berrygenomics.com>"]
 license = "MIT/Apache-2.0"
 readme  = "README.md"

--- a/src/document/doc_store.rs
+++ b/src/document/doc_store.rs
@@ -54,6 +54,7 @@ impl Jx9 for UnQLite {
 /// Wrapper for native [`unqlite_vm`](https://unqlite.org/c_api_object.html#unqlite_vm) structure,
 /// related [functions](https://unqlite.org/c_api_func.html)
 /// and [configuration](https://unqlite.org/c_api/unqlite_vm_config.html).
+#[derive(Clone)]
 pub struct UnQLiteVm {
     native: NonNull<unqlite_vm>,
     executed: bool,


### PR DESCRIPTION
I think UnQLiteVm needs a Clone trait for the following scenario:

I have a Jx9-script that can search in DB and return some result. Multiple clients want to use it at the same time (asynchronously) to get data from DB. They must somehow pass their search parameters to script. The only way I found is to use `add_argument` method, but it requires to have a mutable reference to UnQLiteVm. So I need to make a `Mutex` or `RfCell` and still each client will lock the UnQLiteVm instance.

The simple solution is to spawn UnQLiteVm on each request, but I'm afraid that `UnQLite::complie()` will cause unnecessary CPU and IO usage. But with this trait we can copy comiled version of UnQLiteVm for each client -- not much overhead.

Also I've updated upstream repo to current version, all tests have passed.