### PR TITLE
Migrated from `concat_idents` to `paste`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ bindgen = "0.32"
 cc = "1.0"
 
 [dependencies]
+paste = "0.1"
 libc = "0.2"
 
 [dev-dependencies]

--- a/src/kv_cursor.rs
+++ b/src/kv_cursor.rs
@@ -185,7 +185,9 @@ struct RawCursor {
 macro_rules! eval {
     ($i: ident, $($e: expr),*) => (
         unsafe {
-            concat_idents!(unqlite_kv_cursor_, $i)($($e),*)
+            paste::expr! {
+                [<unqlite_kv_cursor_ $i>]($($e),*)
+            }
         }
     );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,12 +75,13 @@
 //! [docs]: https://zitsen.github.io/unqlite.rs
 //! [license-badge]: https://img.shields.io/crates/l/unqlite.svg?style=flat-square
 
-#![feature(concat_idents)]
-
 extern crate libc;
 
 #[cfg(test)]
 extern crate tempfile;
+
+#[macro_use]
+extern crate paste;
 
 pub use error::{Error, Result};
 use error::Wrap;
@@ -110,7 +111,9 @@ pub struct UnQLite {
 macro_rules! eval {
     ($i: ident, $($e: expr),*) => (
         unsafe {
-            concat_idents!(unqlite_, $i)($($e),*)
+            paste::expr! {
+                [<unqlite_ $i>]($($e),*)
+            }
         }
     );
 }


### PR DESCRIPTION
The `paste` crate works on stable, so this change means that unqlite now
compiles and runs on stable rust.