### PR TITLE
Removed deprecated functions and minor update to unqlite.rs. 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,14 @@ repository = "https://github.com/zitsen/unqlite.rs.git"
 documentation = "https://docs.rs/unqlite"
 description = "Rust `unqlite` library wrapper."
 keywords = ["unqlite", "kv", "nosql"]
+edition = "2018"
 
 [build-dependencies]
-bindgen = "0.49"
+bindgen = "0.55"
 cc = "1"
 
 [dependencies]
-paste = "0.1"
+paste = "1.0"
 libc = "0.2"
 
 [dev-dependencies]

--- a/examples/temp.rs
+++ b/examples/temp.rs
@@ -1,0 +1,28 @@
+use unqlite::{UnQLite, KV, Cursor};
+
+fn main() {
+    // The database memory is not handled by Rust, and the database is on-disk,
+    // so `mut` is not neccessary.
+    let unqlite = UnQLite::create_temp();
+    // Use any type that can use as `[u8]`
+    unqlite.kv_store("key", "a long length value").unwrap();
+    unqlite.kv_store("abc", [1,2,3]).unwrap();
+
+    let mut entry = unqlite.first();
+    // Iterate records
+    loop {
+        if entry.is_none() { break; }
+
+        let record = entry.expect("valid entry");
+        let (key, value) = record.key_value();
+        println!("* Go through {:?} --> {:?}", key, value);
+
+        if value.len() > 10 {
+            println!("** Delete key {:?} by value length", key);
+            entry = record.delete();
+        } else {
+            entry = record.next();
+        }
+    }
+    
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,15 +1,15 @@
-use error::Wrap;
-use ffi::unqlite_config;
+use crate::error::Wrap;
+use crate::ffi::unqlite_config;
 use libc::strlen;
 use std::ffi::CString;
 use std::mem;
 use std::os::raw::c_char;
 use std::ptr;
-use vars::{
+use crate::vars::{
     UNQLITE_CONFIG_DISABLE_AUTO_COMMIT, UNQLITE_CONFIG_ERR_LOG, UNQLITE_CONFIG_GET_KV_NAME,
     UNQLITE_CONFIG_JX9_ERR_LOG, UNQLITE_CONFIG_KV_ENGINE, UNQLITE_CONFIG_MAX_PAGE_CACHE,
 };
-use UnQLite;
+use crate::UnQLite;
 
 /// A `Trait` for configuration.
 ///
@@ -154,7 +154,7 @@ fn from_chars_to_string(p: *mut c_char) -> String {
 #[cfg(feature = "enable-threads")]
 mod tests {
     use super::Config;
-    use UnQLite;
+    use crate::UnQLite;
     #[test]
     fn max_page_cache() {
         let unqlite = UnQLite::create_temp().max_page_cache(512000000);

--- a/src/config.rs
+++ b/src/config.rs
@@ -97,8 +97,8 @@ impl Config for UnQLite {
     }
 
     fn err_log(&self) -> Option<String> {
-        let log: *mut c_char = unsafe { mem::uninitialized() };
-        let len: i32 = unsafe { mem::uninitialized() };
+        let log: *mut c_char = unsafe { mem::MaybeUninit::uninit().assume_init() };
+        let len: i32 = unsafe { mem::MaybeUninit::uninit().assume_init() };
 
         wrap_raw!(self, config, UNQLITE_CONFIG_ERR_LOG, &log, &len)
             .ok()
@@ -112,8 +112,8 @@ impl Config for UnQLite {
     }
 
     fn jx9_err_log(&self) -> Option<String> {
-        let log: *mut c_char = unsafe { mem::uninitialized() };
-        let len: i32 = unsafe { mem::uninitialized() };
+        let log: *mut c_char = unsafe { mem::MaybeUninit::uninit().assume_init() };
+        let len: i32 = unsafe { mem::MaybeUninit::uninit().assume_init() };
         wrap_raw!(self, config, UNQLITE_CONFIG_JX9_ERR_LOG, &log, &len)
             .ok()
             .and_then(|_| {
@@ -126,7 +126,7 @@ impl Config for UnQLite {
     }
 
     fn kv_name(&self) -> String {
-        let kv_name: *mut c_char = unsafe { mem::uninitialized() };
+        let kv_name: *mut c_char = unsafe { mem::MaybeUninit::uninit().assume_init() };
 
         wrap_raw!(self, config, UNQLITE_CONFIG_GET_KV_NAME, &kv_name).unwrap();
         from_chars_to_string(kv_name)

--- a/src/document/doc_store.rs
+++ b/src/document/doc_store.rs
@@ -1,6 +1,6 @@
 use super::vm_value::{to_value, Value};
-use error::{Result, Wrap};
-use ffi::{
+use crate::error::{Result, Wrap};
+use crate::ffi::{
     unqlite_array_add_strkey_elem, unqlite_compile, unqlite_compile_file, unqlite_value,
     unqlite_value_bool, unqlite_value_double, unqlite_value_int64, unqlite_value_null,
     unqlite_value_string, unqlite_vm, unqlite_vm_config, unqlite_vm_dump, unqlite_vm_exec,
@@ -14,13 +14,13 @@ use std::ptr::{null, null_mut, NonNull};
 use std::rc::Rc;
 use std::slice;
 use std::sync::mpsc;
-use vars::{
+use crate::vars::{
     UNQLITE_OK, UNQLITE_VM_CONFIG_ARGV_ENTRY, UNQLITE_VM_CONFIG_CREATE_VAR,
     UNQLITE_VM_CONFIG_ENV_ATTR, UNQLITE_VM_CONFIG_ERR_REPORT, UNQLITE_VM_CONFIG_EXEC_VALUE,
     UNQLITE_VM_CONFIG_EXTRACT_OUTPUT, UNQLITE_VM_CONFIG_IMPORT_PATH, UNQLITE_VM_CONFIG_OUTPUT,
     UNQLITE_VM_CONFIG_RECURSION_DEPTH, UNQLITE_VM_OUTPUT_LENGTH,
 };
-use UnQLite;
+use crate::UnQLite;
 
 /// Jx9 script compiler Interface.
 ///

--- a/src/document/tests.rs
+++ b/src/document/tests.rs
@@ -1,7 +1,7 @@
-use document::Jx9;
-use document::{Map, Value};
+use crate::document::Jx9;
+use crate::document::{Map, Value};
 use std::thread;
-use UnQLite;
+use crate::UnQLite;
 
 // For view stdout of tests run:
 // cargo test document -- --nocapture

--- a/src/document/vm_value.rs
+++ b/src/document/vm_value.rs
@@ -1,4 +1,4 @@
-use ffi::{
+use crate::ffi::{
     unqlite_array_count, unqlite_array_walk, unqlite_value, unqlite_value_is_bool,
     unqlite_value_is_float, unqlite_value_is_int, unqlite_value_is_json_array,
     unqlite_value_is_json_object, unqlite_value_is_null, unqlite_value_is_string,
@@ -8,7 +8,7 @@ use ffi::{
 use std::collections::HashMap;
 use std::os::raw::{c_int, c_void};
 use std::slice;
-use vars::{UNQLITE_ABORT, UNQLITE_OK};
+use crate::vars::{UNQLITE_ABORT, UNQLITE_OK};
 
 /// Map of Values
 pub type Map = HashMap<String, Value>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 use std::error;
 use std::fmt;
 use std::result;
-use vars::*;
+use crate::vars::*;
 
 /// Custom `Result` type.
 pub type Result<T> = result::Result<T, Error>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,15 +39,6 @@ impl fmt::Display for Error {
     }
 }
 
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::Custom(ref c) => c.description(),
-            Error::Other(ref e) => e.as_ref().description(),
-        }
-    }
-}
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Custom {
     kind: ErrorKind,

--- a/src/kv_cursor.rs
+++ b/src/kv_cursor.rs
@@ -210,7 +210,7 @@ macro_rules! wrap_in_place {
 impl RawCursor {
     /// Opening Database Cursors
     pub fn init(unqlite: &UnQLite) -> Result<Self> {
-        let mut cursor: *mut unqlite_kv_cursor = unsafe { mem::uninitialized() };
+        let mut cursor: *mut unqlite_kv_cursor = unsafe { mem::MaybeUninit::uninit().assume_init() };
         wrap!(init, unqlite.as_raw_mut_ptr(), &mut cursor).map(|_| RawCursor {
             engine: unqlite.engine,
             cursor: unsafe { NonNull::new_unchecked(cursor) },

--- a/src/kv_cursor.rs
+++ b/src/kv_cursor.rs
@@ -1,5 +1,5 @@
-use error::{Result, Wrap};
-use ffi::{
+use crate::error::{Result, Wrap};
+use crate::ffi::{
     unqlite, unqlite_kv_cursor, unqlite_kv_cursor_data, unqlite_kv_cursor_data_callback,
     unqlite_kv_cursor_delete_entry, unqlite_kv_cursor_first_entry, unqlite_kv_cursor_init,
     unqlite_kv_cursor_key, unqlite_kv_cursor_key_callback, unqlite_kv_cursor_last_entry,
@@ -9,8 +9,8 @@ use ffi::{
 use std::mem;
 use std::os::raw::c_void;
 use std::ptr::{self, NonNull};
-use vars::{UNQLITE_CURSOR_MATCH_EXACT, UNQLITE_CURSOR_MATCH_GE, UNQLITE_CURSOR_MATCH_LE};
-use UnQLite;
+use crate::vars::{UNQLITE_CURSOR_MATCH_EXACT, UNQLITE_CURSOR_MATCH_GE, UNQLITE_CURSOR_MATCH_LE};
+use crate::UnQLite;
 
 /// Cursor iterator interfaces.
 ///
@@ -349,7 +349,7 @@ mod tests {
     use super::*;
     use std::os::raw::c_void;
     use std::ptr;
-    use {UnQLite, KV};
+    use crate::{UnQLite, KV};
 
     macro_rules! _test_assert_eq {
         ($lhs:expr, ($rhs_0:expr, $rhs_1:expr)) => {{

--- a/src/kv_store.rs
+++ b/src/kv_store.rs
@@ -137,7 +137,7 @@ impl KV for UnQLite {
 
     fn kv_fetch<K: AsRef<[u8]>>(&self, key: K) -> Result<Vec<u8>> {
         let key = key.as_ref();
-        let mut len = try!(self.kv_fetch_length(key));
+        let mut len = self.kv_fetch_length(key)?;
         let mut buf: Vec<u8> = Vec::with_capacity(len as usize);
         let cap = buf.capacity();
         let ptr = buf.as_mut_ptr();

--- a/src/kv_store.rs
+++ b/src/kv_store.rs
@@ -1,5 +1,5 @@
-use error::{Result, Wrap};
-use ffi::{
+use crate::error::{Result, Wrap};
+use crate::ffi::{
     unqlite_kv_append,
     unqlite_kv_config,
     unqlite_kv_delete,
@@ -12,8 +12,8 @@ use ffi::{
 use std::mem;
 use std::os::raw::c_void;
 use std::ptr;
-use vars::{UNQLITE_KV_CONFIG_CMP_FUNC, UNQLITE_KV_CONFIG_HASH_FUNC};
-use UnQLite;
+use crate::vars::{UNQLITE_KV_CONFIG_CMP_FUNC, UNQLITE_KV_CONFIG_HASH_FUNC};
+use crate::UnQLite;
 
 /// Key-Value Store Interface
 pub trait KV {
@@ -195,7 +195,7 @@ impl KV for UnQLite {
 #[cfg(feature = "enable-threads")]
 mod tests {
     use super::KV;
-    use UnQLite;
+    use crate::UnQLite;
 
     #[test]
     fn test_kv_store() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,9 +141,9 @@ impl UnQLite {
     /// ```
     #[inline]
     fn open<P: AsRef<str>>(filename: P, mode: OpenMode) -> Result<UnQLite> {
-        let mut db: *mut ::ffi::unqlite = unsafe { mem::uninitialized() };
+        let mut db: *mut ::ffi::unqlite = unsafe { mem::MaybeUninit::uninit().assume_init() };
         let filename = filename.as_ref();
-        let filename = try!(CString::new(filename));
+        let filename = CString::new(filename)?;
         wrap!(open, &mut db, filename.as_ptr(), mode.into()).map(|_| UnQLite {
             engine: unsafe { NonNull::new_unchecked(db) },
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,9 +75,6 @@
 //! [docs]: https://zitsen.github.io/unqlite.rs
 //! [license-badge]: https://img.shields.io/crates/l/unqlite.svg?style=flat-square
 
-extern crate libc;
-
-extern crate paste;
 #[cfg(test)]
 extern crate tempfile;
 
@@ -103,7 +100,7 @@ use std::ptr::NonNull;
 /// [`open_readonly`](#method.open_readonly) | Open the database in a read-only mode.
 ///
 pub struct UnQLite {
-    engine: NonNull<::ffi::unqlite>,
+    engine: NonNull<crate::ffi::unqlite>,
 }
 
 macro_rules! eval {
@@ -141,7 +138,7 @@ impl UnQLite {
     /// ```
     #[inline]
     fn open<P: AsRef<str>>(filename: P, mode: OpenMode) -> Result<UnQLite> {
-        let mut db: *mut ::ffi::unqlite = unsafe { mem::MaybeUninit::uninit().assume_init() };
+        let mut db: *mut crate::ffi::unqlite = unsafe { mem::MaybeUninit::uninit().assume_init() };
         let filename = filename.as_ref();
         let filename = CString::new(filename)?;
         wrap!(open, &mut db, filename.as_ptr(), mode.into()).map(|_| UnQLite {
@@ -257,7 +254,7 @@ impl UnQLite {
         wrap!(close, self.as_raw_mut_ptr())
     }
 
-    unsafe fn as_raw_mut_ptr(&self) -> *mut ::ffi::unqlite {
+    unsafe fn as_raw_mut_ptr(&self) -> *mut crate::ffi::unqlite {
         self.engine.as_ptr()
     }
 }

--- a/src/openmode.rs
+++ b/src/openmode.rs
@@ -16,15 +16,15 @@ pub use self::OpenMode::*;
 impl Into<u32> for OpenMode {
     fn into(self) -> u32 {
         match self {
-            ReadOnly => ::vars::UNQLITE_OPEN_READONLY,
+            ReadOnly => crate::vars::UNQLITE_OPEN_READONLY,
             // ReadWrite => vars::UNQLITE_OPEN_READWRITE,
-            Create => ::vars::UNQLITE_OPEN_CREATE,
+            Create => crate::vars::UNQLITE_OPEN_CREATE,
             // Exclusive =>vars::UNQLITE_OPEN_EXCLUSIVE,
-            TempDB => ::vars::UNQLITE_OPEN_TEMP_DB,
+            TempDB => crate::vars::UNQLITE_OPEN_TEMP_DB,
             // NoMutex =>vars::UNQLITE_OPEN_NOMUTEX,
             // OmitJournaling =>vars::UNQLITE_OPEN_OMIT_JOURNALING,
             // InMemory =>vars::UNQLITE_OPEN_IN_MEMORY,
-            MMap => ::vars::UNQLITE_OPEN_MMAP | ::vars::UNQLITE_OPEN_READONLY,
+            MMap => crate::vars::UNQLITE_OPEN_MMAP | crate::vars::UNQLITE_OPEN_READONLY,
         }
     }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,6 +1,6 @@
-use error::{Result, Wrap};
-use ffi::{unqlite_begin, unqlite_commit, unqlite_rollback};
-use UnQLite;
+use crate::error::{Result, Wrap};
+use crate::ffi::{unqlite_begin, unqlite_commit, unqlite_rollback};
+use crate::UnQLite;
 
 /// Manual Transaction Manager
 ///
@@ -62,8 +62,8 @@ impl Transaction for UnQLite {
 #[cfg(feature = "enable-threads")]
 mod tests {
     use super::Transaction;
-    use Config;
-    use UnQLite;
+    use crate::Config;
+    use crate::UnQLite;
     #[test]
     fn transaction() {
         let uq = UnQLite::create_temp().disable_auto_commit();

--- a/src/util.rs
+++ b/src/util.rs
@@ -48,11 +48,11 @@ impl Util for UnQLite {
 pub fn load_mmaped_file<P: AsRef<Path>>(path: P) -> Result<Mmap> {
     unsafe {
         let path = path.as_ref();
-        let mut ptr: *mut c_void = mem::uninitialized();
+        let mut ptr: *mut c_void = mem::MaybeUninit::uninit().assume_init();
         let mut size: i64 = 0;
-        let cpath = try!(CString::new(
+        let cpath = CString::new(
             path.to_str().expect("cannot convert the path to str")
-        ));
+        )?;
         unqlite_util_load_mmaped_file(cpath.as_ptr(), &mut ptr, &mut size)
             .wrap()
             .map(|_| Mmap {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,5 @@
-use error::{Result, Wrap};
-use ffi::{
+use crate::error::{Result, Wrap};
+use crate::ffi::{
     unqlite_util_load_mmaped_file, unqlite_util_random_num, unqlite_util_random_string,
     unqlite_util_release_mmaped_file,
 };
@@ -7,7 +7,7 @@ use std::ffi::CString;
 use std::mem;
 use std::os::raw::c_void;
 use std::path::Path;
-use UnQLite;
+use crate::UnQLite;
 
 /// Utility interfaces.
 pub trait Util {


### PR DESCRIPTION
While these changes are minor, they do remove deprecated calls and also updated to use 2018 edition. Submodule was also updated and a `examples/temp.rs` was added (which was taken from the readme, might add my own example at a later date, although the current example is more than enough).  